### PR TITLE
bugfix/项目管理/我的任务 新建任务和更新任务设置bug

### DIFF
--- a/pmhub-api/pmhub-api-workflow/src/main/java/com/laigeoffer/pmhub/api/workflow/DeployFeignService.java
+++ b/pmhub-api/pmhub-api-workflow/src/main/java/com/laigeoffer/pmhub/api/workflow/DeployFeignService.java
@@ -34,7 +34,7 @@ public interface DeployFeignService {
      * @param approvalSetDTO
      * @return
      */
-    @PostMapping("/workflow/deploy/updateApprovalSet")
+    @PostMapping("/workflow/deploy/updateApprovalSet2")
     R<?> updateApprovalSet2(ApprovalSetDTO approvalSetDTO, @RequestHeader(SecurityConstants.FROM_SOURCE) String source);
 
 

--- a/pmhub-base/pmhub-base-core/src/main/java/com/laigeoffer/pmhub/base/core/core/domain/dto/ApprovalSetDTO.java
+++ b/pmhub-base/pmhub-base-core/src/main/java/com/laigeoffer/pmhub/base/core/core/domain/dto/ApprovalSetDTO.java
@@ -25,6 +25,8 @@ public class ApprovalSetDTO {
         this.definitionId = definitionId;
         this.deploymentId = deploymentId;
     }
+    // jackson反序列化构造函数
+    public ApprovalSetDTO() {}
 
     public String getExtraId() {
         return extraId;

--- a/pmhub-modules/pmhub-workflow/src/main/java/com/laigeoffer/pmhub/workflow/controller/WfDeployController.java
+++ b/pmhub-modules/pmhub-workflow/src/main/java/com/laigeoffer/pmhub/workflow/controller/WfDeployController.java
@@ -124,7 +124,7 @@ public class WfDeployController extends BaseController {
     @InnerAuth
     @PostMapping("/updateApprovalSet")
     @DistributedLock(key = "#approvalSetDTO.approved", lockTime = 10L, keyPrefix = "workflow-approve-")
-    public R<?> updateApprovalSet(ApprovalSetDTO approvalSetDTO) {
+    public R<?> updateApprovalSet(@RequestBody ApprovalSetDTO approvalSetDTO) {
         return R.ok(deployService.updateApprovalSet(approvalSetDTO, ProjectStatusEnum.PROJECT.getStatusName()));
     }
 
@@ -135,7 +135,7 @@ public class WfDeployController extends BaseController {
      */
     @InnerAuth
     @PostMapping("/updateApprovalSet2")
-    public R<?> updateApprovalSet2(ApprovalSetDTO approvalSetDTO) {
+    public R<?> updateApprovalSet2(@RequestBody ApprovalSetDTO approvalSetDTO) {
         return R.ok(deployService.updateApprovalSet2(approvalSetDTO, ProjectStatusEnum.PROJECT.getStatusName()));
     }
 
@@ -157,7 +157,7 @@ public class WfDeployController extends BaseController {
      */
     @InnerAuth
     @PostMapping("/insertOrUpdateApprovalSet")
-    public R<Boolean> insertOrUpdateApprovalSet(ApprovalSetDTO approvalSetDTO) {
+    public R<Boolean> insertOrUpdateApprovalSet(@RequestBody ApprovalSetDTO approvalSetDTO) {
         return R.ok(deployService.insertOrUpdateApprovalSet(approvalSetDTO.getExtraId(), approvalSetDTO.getType(), approvalSetDTO.getApproved(), approvalSetDTO.getDefinitionId(), approvalSetDTO.getDeploymentId()));
     }
 


### PR DESCRIPTION
1. 新建任务Feign接口参数没有加@RequestBody导致参数接受不到
2.更新任务设置Feign接口地址不对
3.ApprovalSetDTO jackson反序列化需要空参构造器，没有的话会报错Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.laigeoffer.pmhub.base.core.core.domain.dto.ApprovalSetDTO` (no Creators, like default constructor, exist)
