### PR TITLE
bugfix/项目管理/我的任务 任务删除bug

### DIFF
--- a/pmhub-modules/pmhub-project/src/main/java/com/laigeoffer/pmhub/project/mapper/ProjectTaskProcessMapper.java
+++ b/pmhub-modules/pmhub-project/src/main/java/com/laigeoffer/pmhub/project/mapper/ProjectTaskProcessMapper.java
@@ -1,0 +1,7 @@
+package com.laigeoffer.pmhub.project.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.laigeoffer.pmhub.project.domain.ProjectTaskProcess;
+
+public interface ProjectTaskProcessMapper extends BaseMapper<ProjectTaskProcess> {
+}

--- a/pmhub-modules/pmhub-project/src/main/java/com/laigeoffer/pmhub/project/service/ProjectTaskService.java
+++ b/pmhub-modules/pmhub-project/src/main/java/com/laigeoffer/pmhub/project/service/ProjectTaskService.java
@@ -2,13 +2,13 @@ package com.laigeoffer.pmhub.project.service;
 
 import com.baomidou.mybatisplus.extension.service.IService;
 import com.github.pagehelper.PageInfo;
+import com.laigeoffer.pmhub.project.domain.ProjectTaskProcess;
 import com.laigeoffer.pmhub.project.domain.vo.project.ProjectVO;
 import com.laigeoffer.pmhub.project.domain.vo.project.log.LogReqVO;
 import com.laigeoffer.pmhub.project.domain.vo.project.log.ProjectLogVO;
 import com.laigeoffer.pmhub.project.domain.Project;
 import com.laigeoffer.pmhub.project.domain.ProjectTask;
 import com.laigeoffer.pmhub.project.domain.vo.project.member.ProjectMemberResVO;
-import com.laigeoffer.pmhub.project.domain.vo.project.task.*;
 import com.laigeoffer.pmhub.project.domain.vo.project.task.*;
 
 import javax.servlet.http.HttpServletResponse;
@@ -78,5 +78,7 @@ public interface ProjectTaskService extends IService<ProjectTask> {
     Long countTaskNum();
 
     List<Project> queryProjectsStatus(List<String> projectIds);
+
+    List<ProjectTaskProcess> taskProcessList(List<String> taskIds);
 
 }

--- a/pmhub-modules/pmhub-project/src/main/java/com/laigeoffer/pmhub/project/service/impl/ProjectTaskServiceImpl.java
+++ b/pmhub-modules/pmhub-project/src/main/java/com/laigeoffer/pmhub/project/service/impl/ProjectTaskServiceImpl.java
@@ -2,6 +2,7 @@ package com.laigeoffer.pmhub.project.service.impl;
 
 import com.alibaba.fastjson2.JSON;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.toolkit.Wrappers;
 import com.baomidou.mybatisplus.extension.conditions.update.LambdaUpdateChainWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.github.pagehelper.PageHelper;
@@ -75,6 +76,8 @@ public class ProjectTaskServiceImpl extends ServiceImpl<ProjectTaskMapper, Proje
     private QueryTaskLogFactory queryTaskLogFactory;
     @Autowired
     private ProjectFileMapper projectFileMapper;
+    @Autowired
+    private ProjectTaskProcessMapper projectTaskProcessMapper;
 
     // 远程调用流程服务
     @Resource
@@ -916,6 +919,13 @@ public class ProjectTaskServiceImpl extends ServiceImpl<ProjectTaskMapper, Proje
     @Override
     public List<Project> queryProjectsStatus(List<String> projectIds) {
         return projectTaskMapper.queryProjectsStatus(projectIds);
+    }
+
+    @Override
+    public List<ProjectTaskProcess> taskProcessList(List<String> taskIds) {
+        LambdaQueryWrapper<ProjectTaskProcess> queryWrapper = Wrappers.lambdaQuery();
+        queryWrapper.in(ProjectTaskProcess::getExtraId, taskIds);
+        return projectTaskProcessMapper.selectList(queryWrapper);
     }
 
 }


### PR DESCRIPTION
1.删除任务的时候报错，19:04:26.099 [http-nio-6808-exec-2] ERROR c.l.p.b.s.h.GlobalExceptionHandler - [handleHttpRequestMethodNotSupported,45] - 请求地址'/workflow/deploy/selectList',不支持'POST'请求
原因是Feign接口，如果是Get请求，参数没有使用@RequestParam的话，会被转为Post请求
![image](https://github.com/user-attachments/assets/bee202dd-9d0c-474f-b4aa-25ee713a78b7)

2.**但是基于现在的设计，pmhub_project_task_process表是在pmhub-project库中，所以删除任务的时候不需要调用pmhub-workflow流程服务**